### PR TITLE
Add explicit check for calexp dataset existence in the repo.

### DIFF
--- a/python/lsst/fgcmcal/fgcmBuildStarsTable.py
+++ b/python/lsst/fgcmcal/fgcmBuildStarsTable.py
@@ -140,6 +140,11 @@ class FgcmBuildStarsTableTask(FgcmBuildStarsBaseTask):
                 except RuntimeError:
                     # Not found
                     continue
+
+                # Make sure the dataset exists
+                if not calexpRef.datasetExists():
+                    continue
+
                 # It was found.  Add and quit out, since we only
                 # need one calexp per visit.
                 groupedDataRefs[visit].append(calexpRef)


### PR DESCRIPTION
Just having a dataref is insufficient in the case that a raw exists
but ISR processing failed.

Conflicts:
	python/lsst/fgcmcal/fgcmBuildStarsTable.py